### PR TITLE
Temporarily remove obsolete APIs

### DIFF
--- a/quality/rules-checkstyle.xml
+++ b/quality/rules-checkstyle.xml
@@ -41,10 +41,6 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
 
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="130"/>
-        </module>
-
         <module name="RightCurly">
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>


### PR DESCRIPTION
hi @mikedw ,

The `maxLineLength` has been removed from the latest **Checkstyle** APIs,  keep using this property would cause the compilation error. #1 